### PR TITLE
Blazer missing skin remove

### DIFF
--- a/game/heroes/blazer/hero.entity
+++ b/game/heroes/blazer/hero.entity
@@ -195,7 +195,6 @@
 	<modifier key="Blazer_Ability4_Invis" modpriority="100" passiveeffect="effects/body_invis.effect" />
 	<modifier key="voidkeyactive" modpriority="100" passiveeffect="" />
 	
-	<modifier key="gear_1" modpriority="1" altavatar="true" passiveeffect="effects/body.effect" icon2="gear_1/icon.tga" portrait="gear_1/icon.tga" model="gear_1/model.mdf" previewmodel="gear_1/preview.mdf" storemodel="gear_1/preview.mdf" />
 	<modifier key="gear_2" modpriority="1" altavatar="true" passiveeffect="gear_2/effects/body.effect" icon2="gear_2/icon.tga" portrait="gear_2/icon.tga" model="gear_2/model.mdf" previewmodel="gear_2/preview.mdf" storemodel="gear_2/preview.mdf" />
 
 	

--- a/game/heroes/blazer/hero.entity
+++ b/game/heroes/blazer/hero.entity
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hero
+	name="Hero_Blazer"
+
+	showinpractice="true"
+	team="final"
+	icon="icon.tga"
+	portrait="icon.tga" 
+	model="model.mdf"
+	skin=""
+	mapicon="icon_circle.tga"
+	cutouticon="icon_full.tga"
+	
+	passiveeffect="effects/body.effect"
+	spawneffect=""
+	respawneffect="/shared/effects/respawn.effect"
+	selectedsound=""
+	selectedflavorsound=""
+
+	heroselectannouncement="sounds/voice/vo_selecthero_1.wav"
+	heroselectflavorannouncement="sounds/voice/vo_selecthero_2.wav"
+	confirmmovesound="sounds/voice/vo_move_%.wav"
+	confirmattacksound="sounds/voice/vo_attack_%.wav"
+	nomanasound="sounds/voice/vo_oom_%.wav"
+	cooldownsound="sounds/voice/vo_cooldown_%.wav"
+	streaksound="sounds/voice/vo_ck_2.wav,sounds/voice/vo_ck_3.wav,sounds/voice/vo_ck_4.wav,sounds/voice/vo_ck_5.wav"
+	
+	creepkillannouncement="sounds/voice/vo_lasthit_1.wav,sounds/voice/vo_lasthit_2.wav,sounds/voice/vo_lasthit_3.wav"
+	herokillfrequentannouncement="sounds/voice/vo_herokill_%.wav"
+	herokillinfrequentannouncement="sounds/voice/vo_sporadickill_%.wav"
+	herolevelultannouncement="sounds/voice/vo_levelup_1.wav,sounds/voice/vo_levelup_2.wav,sounds/voice/vo_levelup_3.wav"
+	creepdamageannouncement="sounds/voice/vo_creepdamage_%.wav"
+	toweraggroannouncement="sounds/voice/vo_towerdamage.wav"
+	deathannouncement=""
+	respawnannouncement="sounds/voice/vo_spawn_%.wav"
+	itemacquireannouncement=""
+	itempurchaseannouncement="sounds/voice/vo_itempurchase_%.wav"
+	lowhealthannouncement="sounds/voice/vo_lowhealth_%.wav"
+	abilityflavorannouncement="sounds/voice/vo_ability_1.wav,sounds/voice/vo_ability_2.wav,sounds/voice/vo_ability_3.wav,sounds/voice/vo_ability_4.wav"
+		
+	assistannouncement="sounds/voice/vo_ping_assist.wav"
+	attackannouncement="sounds/voice/vo_ping_attack.wav"
+	attackcruxannouncement="sounds/voice/vo_ping_attack_crux.wav"
+	attackenemyannouncement="sounds/voice/vo_ping_attack_enemy.wav"	
+	attackgeneratorannouncement="sounds/voice/vo_ping_attack_generator.wav"
+	attacktowerannouncement="sounds/voice/vo_ping_attack_tower.wav"
+	backannouncement="sounds/voice/vo_ping_back.wav"
+	carebottomannouncement="sounds/voice/vo_ping_careful_bottom.wav"
+	caremiddleannouncement="sounds/voice/vo_ping_careful_mid.wav"
+	caretopannouncement="sounds/voice/vo_ping_careful_top.wav"
+	defendcruxannouncement="sounds/voice/vo_ping_defend_crux.wav"
+	defendgeneratorannouncement="sounds/voice/vo_ping_defend_generator.wav"
+	defendtowerannouncement="sounds/voice/vo_ping_defend_tower.wav"
+	farmannouncement="sounds/voice/vo_ping_farm.wav"
+	helpannouncement="sounds/voice/vo_ping_help.wav"
+	helpbottomannouncement="sounds/voice/vo_ping_help_bottom.wav"
+	helpmiddleannouncement="sounds/voice/vo_ping_help_mid.wav"
+	helptopannouncement="sounds/voice/vo_ping_help_top.wav"
+	krytosannouncement="sounds/voice/vo_ping_krytos.wav"
+	missingannouncement="sounds/voice/vo_ping_missing.wav"
+	missingbottomannouncement="sounds/voice/vo_ping_missing_bottom.wav"		
+	missingmiddleannouncement="sounds/voice/vo_ping_missing_mid.wav"
+	missingtopannouncement="sounds/voice/vo_ping_missing_top.wav"
+	onmywayannouncement="sounds/voice/vo_ping_omw.wav"
+	onmywaybottomannouncement="sounds/voice/vo_ping_omw_bottom.wav"
+	onmywaymiddleannouncement="sounds/voice/vo_ping_omw_mid.wav"
+	onmywaytopannouncement="sounds/voice/vo_ping_omw_top.wav"
+	pushannouncement="sounds/voice/vo_ping_push.wav"
+	thanksannouncement="sounds/voice/vo_ping_thanks.wav"
+	togetherannouncement="sounds/voice/vo_ping_together.wav"
+	watchoutannouncement="sounds/voice/vo_ping_watchout.wav"
+	wellannouncement="sounds/voice/vo_ping_well.wav"
+	wellplayedannouncement="sounds/voice/vo_ping_wellplayed.wav"
+	
+	preglobalscale="1.6"
+	modelscale="1.15"
+	effectscale="1.025"
+	boundsheight="112"
+	boundsradius="24"
+	selectionradius="48"
+	targetoffset="0 0 64"
+	infoheight="300"
+	searchradius="105"
+	minsearchradius="65"
+	searchheight="125"
+
+	revealrange="700"
+	revealtype="hero"
+
+	category="magic"
+	difficulty="4"
+	movespeed="345"
+	turnrate="900"
+	turnsmoothing="0.01"
+	
+	rolesurvival="0"
+	rolecrowdcontrol="2"
+	rolephysicaldamage="4"
+	rolemagicdamage="4"
+	roleutility="2"
+
+	maxhealth="881,941,1002,1063,1123,1184,1244,1305,1366,1426,1487,1548,1608,1669,1730"
+	maxhealthperlevel="0"
+	healthregen="2.02,2.16,2.3,2.44,2.58,2.72,2.86,3,3.14,3.28,3.42,3.56,3.7,3.84,3.98"
+	healthproportionregen="0"
+	
+	unitcriticalmultiplier="1.0"
+	
+	maxmana="320"
+	maxmanaperlevel="15"
+	manaregen="2.11,2.16,2.20,2.24,2.29,2.33,2.37,2.42,2.46,2.51,2.55,2.59,2.64,2.68,2.72"
+	manaproportionregen="0.0"
+
+	resistance="10"
+
+	inventory0="Ability_Blazer1"
+	inventory1="Ability_Blazer2"
+	inventory2="Ability_Blazer3"
+	inventory3="Ability_Blazer4"
+	inventory4=""
+	inventory5=""
+	inventory6=""
+	inventory7=""
+	inventory8="Ability_HomecomingStone_Home"
+	inventory9=""
+	inventory10="Ability_WardSwitch"
+	inventory11="Ability_AutomatedCourier"
+
+	
+	
+	power="130"
+	attackduration="400"
+	attackactiontime="250"
+	attackcooldown="1100"
+	attackdamagemin="54,56.49,58.97,61.46,63.94,66.43,68.91,71.4,73.89,76.37,78.86,81.34,83.83,86.31,88.8"
+	attackdamageminperlevel="0"
+	attackdamagemax="54,56.49,58.97,61.46,63.94,66.43,68.91,71.4,73.89,76.37,78.86,81.34,83.83,86.31,88.8"
+	attackdamagemaxperlevel="0"
+	attacknumanims="2"
+	tiltfactor="0.0"
+	tiltspeed="90.0"
+	attackoffset="-5 200 200"
+	attackprojectile="Projectile_Blazer_Attack"
+	attackrange="550"
+	attackstarteffect="effects/attack.effect"
+	attackactioneffect=""
+	attackimpacteffect=""
+	critimpacteffect="/shared/effects/crit_impact.effect"
+	attacktype="ranged"
+	attackdamagetype="AttackDamage"
+	combattype="Hero"
+
+	aggrorange="800"
+	sightrangeday="1500"
+	sightrangenight="1500"
+	wanderrange="250"
+
+	primaryattribute="Intelligence"
+	strength="0"
+	strengthperlevel="0"
+	agility="0"
+	agilityperlevel="0"
+	intelligence="0"
+	intelligenceperlevel="0"
+	
+	previewpassiveeffect="effects/preview.effect"
+	previewmodel="preview.mdf"
+	previewpos="18 0 -180"
+	previewangles="25 0 0"
+	previewscale="1.33"
+	
+	storemodel="preview.mdf"
+	storepos="0 0 -120"
+	storeangles="0 0 0"
+	storescale="1.45"
+	
+	occlusionstealthtype="occlusion"
+	occlusionfadeineffect="/shared/effects/fade_in.effect"
+	occlusionfadeouteffect="/shared/effects/fade_out.effect"
+	
+	defaultfamiliar="Familiar_Razer"
+	itembuild="Blazer"
+	levelbuild="1,2,3,2,2,4,2,3,3,3,4,1,1,1,4"
+	
+	corpsetime="1500"
+	corpsefadetime="4000"
+	corpsefadeeffect="/shared/effects/corpse_sink.effect"
+	
+>
+	<modifier key="counterstrife" modpriority="1" healthregen="0" manaregen="0" inventory8="" inventory9="Ability_SpawnInvulnerability" inventory10="" inventory11="" dropitemsondeath="true" movespeed="500" sightrangeday="1000" sightrangenight="1000" />
+	<modifier key="Blazer_Ability1_Charging" priority="100" walkanim="ability_1_walk" idleanim="ability_1_aim" abilityflavorannouncement="sounds/voice/vo_ability_1_2.wav,sounds/voice/vo_ability_2.wav,sounds/voice/vo_ability_3.wav,sounds/voice/vo_ability_4.wav" />
+	<modifier key="frost" modpriority="100" attackprojectile="Projectile_Frost"/> 
+	<modifier key="shop_access_dead" condition="!alive" modpriority="100" exclusive="true" shopaccess="Shop_Utility Shop_Basic Shop_Boots Shop_Consumables Shop_MagicDefense Shop_PhysicalDefense Shop_VitalBoosters Shop_Artifacts Shop_Offense Shop_Crafted" stashaccess="true"/>
+	<modifier key="no_aggro" modpriority="100" defaultbehavior="aggro"/>
+	<modifier key="Blazer_Ability4_Invis" modpriority="100" passiveeffect="effects/body_invis.effect" />
+	<modifier key="voidkeyactive" modpriority="100" passiveeffect="" />
+	
+	<modifier key="gear_1" modpriority="1" altavatar="true" passiveeffect="effects/body.effect" icon2="gear_1/icon.tga" portrait="gear_1/icon.tga" model="gear_1/model.mdf" previewmodel="gear_1/preview.mdf" storemodel="gear_1/preview.mdf" />
+	<modifier key="gear_2" modpriority="1" altavatar="true" passiveeffect="gear_2/effects/body.effect" icon2="gear_2/icon.tga" portrait="gear_2/icon.tga" model="gear_2/model.mdf" previewmodel="gear_2/preview.mdf" storemodel="gear_2/preview.mdf" />
+
+	
+</hero>


### PR DESCRIPTION
Blazer had extra skin, which doesn't exist in game files. As result we had white rectangle in hero select screen. The fix removes the skin from hero.entity.
![2024-09-08_16-39-29](https://github.com/user-attachments/assets/1069bd88-594f-4e00-bac6-65fe08f4fb7d)
